### PR TITLE
feat: add skill auto-routing to UserPromptSubmit hook

### DIFF
--- a/.claude/hooks/agent-router.py
+++ b/.claude/hooks/agent-router.py
@@ -1,16 +1,159 @@
 #!/usr/bin/env python3
 """
-UserPromptSubmit hook: Route to appropriate agent based on user intent.
+UserPromptSubmit hook: Unified intent router for skills and agents.
 
-Suggests OpenCode for explicit design/debug consultation requests,
-and Gemini for external research and multimodal tasks only.
-Narrowed triggers to avoid noise on routine tasks.
+Routes user prompts to the appropriate skill or agent:
+1. If an explicit skill command (/startproject, /team-implement, etc.) is present, do nothing.
+2. Detect skill intent (startproject, team-implement, team-review, deploy).
+3. Detect agent intent (OpenCode, Gemini).
+4. Exclude lightweight tasks (questions, single-file edits, explanations).
+
+Output: additionalContext suggesting the best action (soft recommendation, not forced).
+
+Priority: explicit command > skill intent > agent intent > none
 """
 
 import json
+import re
 import sys
 
-# Triggers for OpenCode — only explicit consultation requests
+# ---------------------------------------------------------------------------
+# Skill intent triggers
+# ---------------------------------------------------------------------------
+
+STARTPROJECT_TRIGGERS = {
+    "ja": [
+        "新機能を",
+        "新しい機能",
+        "機能を作",
+        "機能を開発",
+        "機能を実装したい",
+        "プロジェクトを始",
+        "プロジェクト開始",
+        "計画して",
+        "計画を立てて",
+        "設計から始",
+        "要件定義",
+        "要件を整理",
+        "新規開発",
+        "featureを始",
+        "featureを進",
+        "開発を始めたい",
+        "作りたい",
+        "構築したい",
+        "issue #",
+        "issueを実行",
+        "issueを進",
+        "チケットを進",
+        "チケットを実行",
+        "タスクを始",
+        "タスクを進",
+        "githubの#",
+        "githubの #",
+    ],
+    "en": [
+        "start project",
+        "start a project",
+        "start new feature",
+        "plan this feature",
+        "plan the feature",
+        "begin development",
+        "kick off",
+        "start building",
+        "new feature",
+        "implement issue",
+        "work on issue",
+        "execute issue",
+    ],
+}
+
+TEAM_IMPLEMENT_TRIGGERS = {
+    "ja": [
+        "実装して",
+        "実装を開始",
+        "実装に進",
+        "実装を始",
+        "実装フェーズ",
+        "コードを書いて",
+        "この計画で実装",
+        "承認した",
+        "承認します",
+        "進めて",
+        "計画通りに",
+        "計画で進めて",
+        "実装に入",
+        "コーディング",
+    ],
+    "en": [
+        "implement this",
+        "start implementing",
+        "begin implementation",
+        "approved, implement",
+        "go ahead and implement",
+        "proceed with implementation",
+        "code this up",
+        "start coding",
+    ],
+}
+
+TEAM_REVIEW_TRIGGERS = {
+    "ja": [
+        "レビューして",
+        "レビューを",
+        "コードレビュー",
+        "差分レビュー",
+        "実装のレビュー",
+        "品質チェック",
+        "セキュリティチェック",
+        "実装が終わった",
+        "実装完了",
+        "レビューに進",
+        "チェックして",
+    ],
+    "en": [
+        "review this",
+        "code review",
+        "review the implementation",
+        "review the code",
+        "check the implementation",
+        "quality review",
+        "security review",
+        "implementation is done",
+        "ready for review",
+    ],
+}
+
+DEPLOY_TRIGGERS = {
+    "ja": [
+        "デプロイ",
+        "PRを作",
+        "PR作成",
+        "pushして",
+        "プッシュして",
+        "マージ",
+        "リリース",
+        "本番に",
+        "ブランチをpush",
+        "PRを出",
+    ],
+    "en": [
+        "deploy",
+        "create pr",
+        "create a pr",
+        "create pull request",
+        "push to remote",
+        "push the branch",
+        "merge this",
+        "release this",
+        "ship it",
+        "send pr",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Agent intent triggers (preserved from original)
+# ---------------------------------------------------------------------------
+
 OPENCODE_TRIGGERS = {
     "ja": [
         "設計相談",
@@ -33,7 +176,6 @@ OPENCODE_TRIGGERS = {
     ],
 }
 
-# Triggers for Gemini — external research and multimodal only
 GEMINI_TRIGGERS = {
     "ja": [
         "調べて",
@@ -56,9 +198,136 @@ GEMINI_TRIGGERS = {
     ],
 }
 
+# ---------------------------------------------------------------------------
+# Lightweight task exclusion patterns
+# ---------------------------------------------------------------------------
 
-def detect_agent(prompt: str) -> tuple[str | None, str]:
-    """Detect which agent should handle this prompt."""
+# Patterns that indicate a question or explanation request (not a skill invocation).
+# These are checked ONLY when no strong skill trigger is found, to avoid
+# false negatives on prompts like "新機能を作りたい" which contain "作りたい".
+QUESTION_PATTERNS = {
+    "ja": [
+        "とは何",
+        "って何",
+        "ってなに",
+        "を教えて",
+        "を説明して",
+        "の意味は",
+        "の違いは",
+        "はどういう",
+        "なぜ失敗",
+        "なぜ動かない",
+        "どうして",
+        "見せて",
+        "表示して",
+    ],
+    "en": [
+        "what is",
+        "what are",
+        "how does",
+        "how do",
+        "why does",
+        "why is",
+        "explain",
+        "show me",
+        "display",
+        "can you tell",
+        "tell me about",
+        "describe",
+    ],
+}
+
+# Single-file or lightweight operations that should NOT trigger a workflow skill.
+# Only used as a secondary filter (skill triggers always win).
+LIGHTWEIGHT_OPERATION_PATTERNS = {
+    "ja": [
+        "コミットして",
+        "コミットを作",
+        "直して",
+        "リネームして",
+        "フォーマットして",
+        "lintして",
+        "テストを実行して",
+    ],
+    "en": [
+        "just commit",
+        "fix this typo",
+        "rename this",
+        "format this",
+        "run lint",
+        "run test",
+        "run the test",
+    ],
+}
+
+# Explicit skill command pattern (user already typed the skill name)
+EXPLICIT_SKILL_RE = re.compile(
+    r"^/(?:startproject|team-implement|team-review|deploy)\b", re.IGNORECASE
+)
+
+
+# ---------------------------------------------------------------------------
+# Detection logic
+# ---------------------------------------------------------------------------
+
+
+def has_explicit_skill(prompt: str) -> bool:
+    """Check if the prompt already contains an explicit skill command."""
+    return bool(EXPLICIT_SKILL_RE.search(prompt.strip()))
+
+
+def is_lightweight_task(prompt: str, has_skill_trigger: bool = False) -> bool:
+    """Check if the prompt is a lightweight task that should not trigger a skill.
+
+    If a strong skill trigger was already found, we skip suppression entirely --
+    the user's intent to invoke a skill takes precedence.
+    """
+    # If we already found a strong skill trigger, don't suppress
+    if has_skill_trigger:
+        return False
+
+    prompt_lower = prompt.lower()
+
+    # Question patterns suppress skill routing
+    for patterns in QUESTION_PATTERNS.values():
+        for pattern in patterns:
+            if pattern in prompt_lower:
+                return True
+
+    # Lightweight operations suppress skill routing
+    for patterns in LIGHTWEIGHT_OPERATION_PATTERNS.values():
+        for pattern in patterns:
+            if pattern in prompt_lower:
+                return True
+
+    return False
+
+
+def detect_skill_intent(prompt: str) -> tuple[str | None, str]:
+    """Detect which skill the user likely wants to invoke.
+
+    Returns (skill_name, matched_trigger) or (None, "").
+    """
+    prompt_lower = prompt.lower()
+
+    skill_candidates = [
+        ("startproject", STARTPROJECT_TRIGGERS),
+        ("team-implement", TEAM_IMPLEMENT_TRIGGERS),
+        ("team-review", TEAM_REVIEW_TRIGGERS),
+        ("deploy", DEPLOY_TRIGGERS),
+    ]
+
+    for skill_name, triggers in skill_candidates:
+        for lang_triggers in triggers.values():
+            for trigger in lang_triggers:
+                if trigger in prompt_lower:
+                    return skill_name, trigger
+
+    return None, ""
+
+
+def detect_agent_intent(prompt: str) -> tuple[str | None, str]:
+    """Detect which agent should handle this prompt (OpenCode or Gemini)."""
     prompt_lower = prompt.lower()
 
     for triggers in OPENCODE_TRIGGERS.values():
@@ -74,41 +343,113 @@ def detect_agent(prompt: str) -> tuple[str | None, str]:
     return None, ""
 
 
+# ---------------------------------------------------------------------------
+# Skill descriptions for additionalContext
+# ---------------------------------------------------------------------------
+
+SKILL_DESCRIPTIONS = {
+    "startproject": (
+        "[Skill Routing] Detected project/feature start intent (trigger: '{trigger}'). "
+        "This looks like a new feature or project task. "
+        "Use `/startproject` skill to begin the planning workflow: "
+        "codebase analysis, requirements gathering, design, and implementation planning. "
+        "Run: /startproject {prompt_summary}"
+    ),
+    "team-implement": (
+        "[Skill Routing] Detected implementation intent (trigger: '{trigger}'). "
+        "This looks like a request to implement an approved plan. "
+        "Use `/team-implement` skill for parallel implementation with Agent Teams. "
+        "Run: /team-implement"
+    ),
+    "team-review": (
+        "[Skill Routing] Detected review intent (trigger: '{trigger}'). "
+        "This looks like a request to review implemented code. "
+        "Use `/team-review` skill for parallel code review with specialized reviewers. "
+        "Run: /team-review"
+    ),
+    "deploy": (
+        "[Skill Routing] Detected deploy/PR intent (trigger: '{trigger}'). "
+        "This looks like a request to push and create a PR. "
+        "Use `/deploy` skill to push the feature branch, create a PR, and return to the original branch. "
+        "Run: /deploy"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Main routing logic
+# ---------------------------------------------------------------------------
+
+
+def route_prompt(prompt: str) -> dict | None:
+    """Route the prompt to the best skill or agent.
+
+    Returns a hookSpecificOutput dict or None if no routing is needed.
+    """
+    # 1. If user already typed an explicit skill command, do nothing
+    if has_explicit_skill(prompt):
+        return None
+
+    # 2. Check for skill intent (highest priority for non-lightweight tasks)
+    skill, trigger = detect_skill_intent(prompt)
+    if skill and not is_lightweight_task(prompt, has_skill_trigger=True):
+        # Build a short summary of the prompt for the skill argument
+        prompt_summary = prompt.strip()[:80]
+        if len(prompt.strip()) > 80:
+            prompt_summary += "..."
+
+        context_msg = SKILL_DESCRIPTIONS[skill].format(
+            trigger=trigger,
+            prompt_summary=prompt_summary,
+        )
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": context_msg,
+            }
+        }
+
+    # 3. Check for agent intent (OpenCode / Gemini)
+    agent, trigger = detect_agent_intent(prompt)
+    if agent == "opencode":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    f"[Agent Routing] Detected '{trigger}' - consider using "
+                    "OpenCode CLI for deep reasoning. "
+                    "Use subagent for context isolation."
+                ),
+            }
+        }
+    elif agent == "gemini":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": (
+                    f"[Agent Routing] Detected '{trigger}' - consider using "
+                    "Gemini CLI for external research or multimodal processing. "
+                    "Use subagent for context isolation."
+                ),
+            }
+        }
+
+    # 4. No routing needed
+    return None
+
+
 def main():
     try:
         data = json.load(sys.stdin)
         prompt = data.get("prompt", "")
 
-        if len(prompt) < 15:
+        # Skip empty or trivially short prompts
+        if len(prompt) < 5:
             sys.exit(0)
 
-        agent, trigger = detect_agent(prompt)
-
-        if agent == "opencode":
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "UserPromptSubmit",
-                    "additionalContext": (
-                        f"[Agent Routing] Detected '{trigger}' - consider using "
-                        "OpenCode CLI for deep reasoning. "
-                        "Use subagent for context isolation."
-                    ),
-                }
-            }
-            print(json.dumps(output))
-
-        elif agent == "gemini":
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "UserPromptSubmit",
-                    "additionalContext": (
-                        f"[Agent Routing] Detected '{trigger}' - consider using "
-                        "Gemini CLI for external research or multimodal processing. "
-                        "Use subagent for context isolation."
-                    ),
-                }
-            }
-            print(json.dumps(output))
+        result = route_prompt(prompt)
+        if result:
+            print(json.dumps(result))
 
         sys.exit(0)
 

--- a/.claude/rules/skill-auto-routing.md
+++ b/.claude/rules/skill-auto-routing.md
@@ -1,0 +1,81 @@
+# Skill Auto-Routing
+
+**UserPromptSubmit hook automatically suggests the appropriate skill based on user intent.**
+
+## Overview
+
+When a user types a prompt, the `agent-router.py` hook analyzes it and suggests one of 4 core skills via `additionalContext`. This is a **soft recommendation** -- Claude should follow it unless the user's intent is clearly different.
+
+## How It Works
+
+The hook runs on every `UserPromptSubmit` event and follows this priority:
+
+```
+1. Explicit skill command detected? → Do nothing (user already specified)
+2. Skill intent detected + NOT lightweight? → Suggest skill
+3. Agent intent detected (OpenCode/Gemini)? → Suggest agent
+4. None of the above → No suggestion
+```
+
+## When to Follow the Suggestion
+
+**MUST follow** the skill suggestion when:
+- The `additionalContext` contains `[Skill Routing]`
+- The user's prompt clearly aligns with the suggested skill's purpose
+- There is no conflicting explicit instruction from the user
+
+**MAY ignore** the skill suggestion when:
+- The user explicitly asks for something different from the suggested skill
+- The task is clearly too small for the suggested workflow (e.g., XS task suggested for /startproject)
+- The user asks a follow-up question within an existing workflow
+
+## Skill Intent Triggers
+
+### /startproject
+- New feature or project requests
+- Issue/ticket execution requests
+- Planning and requirements gathering
+- Keywords: "new feature", "start project", "plan", "issue #", "develop"
+
+### /team-implement
+- Approved plan ready for implementation
+- Explicit implementation requests after planning
+- Keywords: "implement", "code this", "approved", "proceed"
+
+### /team-review
+- Code review requests after implementation
+- Quality or security check requests
+- Keywords: "review", "check", "quality", "security review"
+
+### /deploy
+- PR creation, push, or deployment requests
+- Keywords: "deploy", "create PR", "push", "merge", "release"
+
+## Lightweight Task Exclusion
+
+The following are NOT routed to skills:
+- Questions and explanations ("what is", "why", "explain")
+- Single-file operations ("fix this", "rename", "format")
+- Direct commands ("commit", "lint", "run tests")
+- Short prompts (under 30 characters)
+
+## Interaction with Existing Hooks
+
+- `agent-router.py` handles **both** skill routing and agent routing in a single hook
+- Skill routing takes priority over agent routing
+- `enforce-tool-routing.py` (PreToolUse) is unaffected -- it handles Bash command routing
+- Skills with `context: fork` bypass PreToolUse hooks entirely
+
+## For Claude: Responding to Skill Suggestions
+
+When you receive a `[Skill Routing]` suggestion in additionalContext:
+
+1. **Acknowledge the suggestion** to the user (in Japanese)
+2. **Invoke the suggested skill** using the Skill tool
+3. If the suggestion seems wrong, explain why and ask the user what they prefer
+
+Example response pattern:
+```
+ユーザーの意図は新機能の開発のようです。`/startproject` で計画フェーズを開始します。
+→ /startproject {feature description}
+```

--- a/.claude/rules/tool-routing.md
+++ b/.claude/rules/tool-routing.md
@@ -1,9 +1,39 @@
 # Tool Routing Rules
 
-**Defines which tools and operations are delegated to which agent.**
+**Defines which tools and operations are delegated to which agent, and how skills are auto-routed.**
 
 This file complements agent-specific rules (`opencode-delegation.md`, `gemini-delegation.md`)
 by providing cross-cutting routing decisions.
+
+## Skill Auto-Routing
+
+**ユーザーがスキル名を明示しなくても、`UserPromptSubmit` hook (`agent-router.py`) がプロンプトを分析し、適切なスキルを `additionalContext` で提案する。**
+
+→ 詳細: `.claude/rules/skill-auto-routing.md`
+
+### ルーティング優先順位
+
+```
+1. 明示的スキルコマンド (/startproject 等) → そのまま実行
+2. スキル意図検出 + 軽量タスクでない → スキルを提案
+3. エージェント意図検出 (OpenCode/Gemini) → エージェントを提案
+4. いずれにも該当しない → 通常応答
+```
+
+### スキル意図の発火条件
+
+| スキル | 典型的なトリガー |
+|--------|----------------|
+| `/startproject` | 「新機能を作りたい」「issue #Nを進めたい」「計画して」 |
+| `/team-implement` | 「実装して」「承認します」「この計画で進めて」 |
+| `/team-review` | 「レビューして」「品質チェック」「実装完了」 |
+| `/deploy` | 「PRを作って」「pushして」「デプロイ」 |
+
+### 発火しないケース
+
+- 質問・説明依頼
+- 単発の軽微な操作（コミット、lint、テスト実行など）
+- 短すぎるプロンプト（5文字未満）
 
 ## `context: fork` スキルの直接実行
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,27 @@ Claude Code (Opus 4.6) のコンテキストは **1M トークン**（実質 **3
 
 → 詳細: `/startproject`, `/team-implement`, `/team-review` skills
 
+### Skill Auto-Routing (MUST FOLLOW)
+
+**スキル名を明示しなくても、ユーザーの意図に応じて自動的にスキルが提案される。**
+
+`UserPromptSubmit` hook (`agent-router.py`) がプロンプトを分析し、4つのスキルのいずれかを `additionalContext` で提案する。
+
+| ユーザーの意図 | 提案されるスキル | 例 |
+|--------------|----------------|-----|
+| 新機能・プロジェクト開始 | `/startproject` | 「新機能を作りたい」「issueを進めたい」 |
+| 承認済み計画の実装 | `/team-implement` | 「この計画で実装して」「実装を開始」 |
+| 実装済みコードのレビュー | `/team-review` | 「レビューして」「品質チェック」 |
+| PR作成・push | `/deploy` | 「PRを作って」「デプロイして」 |
+
+**自動ルーティングが発火しないケース（例外的な処理）:**
+- 質問・説明依頼（「これは何？」「なぜ失敗した？」）
+- 単発の軽微な操作（「コミットして」「修正して」「フォーマットして」）
+- 短いプロンプト（5文字未満）
+- 既にスキル名が明示されている場合
+
+→ 詳細: `.claude/hooks/agent-router.py`
+
 ---
 
 ## Tech Stack


### PR DESCRIPTION
## Summary
- Closes #10
- `agent-router.py` を統一インテントルーターに拡張。4つのスキル（startproject, team-implement, team-review, deploy）の意図を自動検出
- `additionalContext` によるソフト推奨方式（hookからスキルを強制起動しない）
- 質問・軽量タスクの除外フィルターで誤検出を防止
- 既存の OpenCode/Gemini エージェントルーティングも維持

## Changes
- `.claude/hooks/agent-router.py`: Unified intent router (skill + agent routing)
- `.claude/rules/skill-auto-routing.md`: New rule file for auto-routing details
- `.claude/rules/tool-routing.md`: Added Skill Auto-Routing section
- `CLAUDE.md`: Added Skill Auto-Routing (MUST FOLLOW) section

## Test plan
- [x] 「新機能を作りたい」 → `/startproject` を提案
- [x] 「実装してください」 → `/team-implement` を提案
- [x] 「レビューして」 → `/team-review` を提案
- [x] 「PRを作って」 → `/deploy` を提案
- [x] 質問系（「とは何ですか」）→ 発火しない
- [x] 軽量操作（「コミットして」）→ 発火しない
- [x] 明示的スキル（`/startproject`）→ 二重発火しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)